### PR TITLE
useEffect에서 mutate 호출 시, 무한 리렌더링이 발생하는 문제 해결

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@confidential-nt/localstorage-query",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "LocalStorage를 좀 더 간편하게 사용하기 위해 만든 라이브러리입니다.",
   "repository": {
     "type": "git",

--- a/packages/lib/src/index.tsx
+++ b/packages/lib/src/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 export default function useLocalstorageQuery<T = undefined>(
   key: string,
@@ -62,27 +62,30 @@ export default function useLocalstorageQuery<T = undefined>(
     value,
   ]);
 
-  const mutate = (newValue: T) => {
-    const value = localStorage.getItem(key);
+  const mutate = useCallback(
+    (newValue: T) => {
+      const value = localStorage.getItem(key);
 
-    const stringifiedNewValue =
-      newValue === undefined
-        ? JSON.stringify('undefined')
-        : JSON.stringify(newValue);
+      const stringifiedNewValue =
+        newValue === undefined
+          ? JSON.stringify('undefined')
+          : JSON.stringify(newValue);
 
-    if (value !== null) {
-      localStorage.setItem(key, stringifiedNewValue);
-      setData(newValue);
-    }
-  };
+      if (value !== null) {
+        localStorage.setItem(key, stringifiedNewValue);
+        setData(newValue);
+      }
+    },
+    [key]
+  );
 
-  const remove = () => {
+  const remove = useCallback(() => {
     const value = localStorage.getItem(key);
     if (value !== null) {
       localStorage.removeItem(key);
       setData(null);
     }
-  };
+  }, [key]);
 
   return {
     data,


### PR DESCRIPTION
### 연관된 이슈
fix #6 

### 문제의 원인

```jsx
  useEffect(() => { // 유저의 현재 위치를 받은 후, 결과를 로컬스토리지에 저장하는 코드
    getUserCurrentPosition().then((position) =>
      mutate({
        latitude: position.coords.latitude,
        longitude: position.coords.longitude,
      })
    );
  }, [mutate]);
```

useEffect가 mutate를 실행시킴으로써 useLocalstorageQuery 훅을 리렌더링하고, 그에 따라 위의 코드에서 useEffect의 의존성인 mutate의 참조값이 변해서 발생하는 문제

### 문제의 해결
useLocalstorageQuery 내부에서, mutate를 useCallback 안에 넣어 함수 정의를 캐싱하도록 하여 문제를 해결

